### PR TITLE
In :sockjs_util.url_escape, use <= instead of <- to use a binary as a generator

### DIFF
--- a/src/sockjs_util.erl
+++ b/src/sockjs_util.erl
@@ -39,7 +39,7 @@ url_escape(Str, Chars) ->
     [case lists:member(Char, Chars) of
          true  -> hex(Char);
          false -> Char
-     end || <<Char>> <- Str].
+     end || <<Char>> <= Str].
 
 hex(C) ->
     <<High:4, Low:4>> = <<C>>,


### PR DESCRIPTION
So I was getting this error for some types of requests:

```
[error] Ranch listener :http had connection process started with :cowboy_protocol:start_link/4 at #PID<0.233.0> exit with reason: {[reason: :function_clause, mfa: {:sockjs_cowboy_handler, :handle, 2}, stacktrace: [{:sockjs_util, :"-url_escape/2-lc$^0/1-0-", ["h"], [file: 'src/sockjs_util.erl', line: 39]}, {:sockjs_action, :fmt_eventsource, 1, [file: 'src/sockjs_action.erl', line: 243]}, {:sockjs_action, :chunk, 3, [file: 'src/sockjs_action.erl', line: 232]}, {:sockjs_action, :reply_loop, 5, [file: 'src/sockjs_action.erl', line: 218]}, {:sockjs_cowboy_handler, :handle, 2, [file: 'src/sockjs_cowboy_handler.erl', line: 25]}, {:cowboy_handler, :handler_handle, 4, [file: 'src/cowboy_handler.erl', line: 111]}, {:cowboy_protocol, :execute, 4, [file: 'src/cowboy_protocol.erl', line: 435]}], req: [socket: #Port<0.7069>, transport: :ranch_tcp, connection: :keepalive, pid: #PID<0.233.0>, method: "GET", version: :"HTTP/1.1", peer: {{127, 0, 0, 1}, 42830}, host: "localhost", host_info: :undefined, port: 3142, path: "/pusher/881/a0gxn4gs/eventsource", path_info: ["881", "a0gxn4gs", "eventsource"], qs: "", qs_vals: :undefined, bindings: [], headers: [{"host", "localhost:3142"}, {"user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0"}, {"accept", "text/event-stream"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate"}, {"dnt", "1"}, {"referer", "http://localhost:3142/pusher/iframe.html"}, {"connection", "keep-alive"}, {"pragma", "no-cache"}, {"cache-control", "no-cache"}], p_headers: [{"connection", ["keep-alive"]}], cookies: :undefined, meta: [], body_state: :waiting, buffer: "", multipart: :undefined, resp_compress: false, resp_state: :waiting, resp_headers: [], resp_body: "", onresponse: :undefined], state: {:service, '/pusher', &AppNameRedacted.SockjsHandler.echo/3, :some_state, 'https://d1fxtkz8shb9d2.cloudfront.net/sockjs-0.3.min.js', false, true, 5000, 25000, 131072, #Function<0.67321156/3 in :sockjs_handler.init_state/4>}], [{:cowboy_protocol, :execute, 4, [file: 'src/cowboy_protocol.erl', line: 435]}]}
```

Turns out the reason was that in commit https://github.com/ericmj/sockjs-erlang/commit/0191809fdfc396941a79ac4ccd488f6f98f86bd4#diff-6aaf21c122862e048d6d39cb3aee03f2L42 , `Str` was changed from a charlist to a binary, but without changing the list comprehension to a binary compehension (`<=` instead of `<-`), which broke the method. This PR fixes that.

Before:

```
iex(3)> :sockjs_util.url_escape("/some-url\r", '%\r\n\0')
** (FunctionClauseError) no function clause matching in :sockjs_util."-url_escape/2-lc$^0/1-0-"/1
    (sockjs) src/sockjs_util.erl:39: :sockjs_util."-url_escape/2-lc$^0/1-0-"("/some-url\r")
```

After:

```
iex(3)> :sockjs_util.url_escape("/some-url\r", '%\r\n\0')
[47, 115, 111, 109, 101, 45, 117, 114, 108, '%0=']
```
